### PR TITLE
update dependency org.slf4j:slf4j-api to v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,17 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
-
+ 
+       <dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-simple</artifactId>
+		    <version>2.0.3</version>
+		</dependency>
+           
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.36</version>
+			<version>2.0.3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The slf4j-api version 2.0.x and later use the [ServiceLoader] mechanism. This solved by including slf4j-simple dependency.
https://www.slf4j.org/codes.html